### PR TITLE
Integrate FakeSV metadata loader, hierarchical fusion model, and data audit tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Ultrafnd_try
 It is a Multimodal fake news detection system project
+
+## Data Audit
+
+Use the provided script to inspect the FakeSV dataset before training. It reports class balance, source distribution, text lengths, and image metadata statistics.
+
+```bash
+python scripts/data_audit.py --data-root /path/to/fakesv \
+    --image-root /path/to/fakesv/images \
+    --embedding-analysis
+```
+
+The optional `--embedding-analysis` flag generates a t-SNE plot of SBERT embeddings.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ torchaudio>=2.2.0
 transformers>=4.40.0
 tokenizers>=0.19.0
 # sentencepiece>=0.1.99
+sentence-transformers>=2.2.2
 
 # Audio
 librosa>=0.10.1
@@ -15,8 +16,11 @@ soundfile>=0.12.1
 # Image/Video processing
 opencv-python-headless>=4.9.0.80
 Pillow>=10.2.0
+pytesseract>=0.3.10
+matplotlib>=3.8.0
 
 # Utilities & metrics
+pandas>=2.1.0
 scikit-learn>=1.4.0
 tqdm>=4.66.0
 pyyaml>=6.0.1

--- a/scripts/data_audit.py
+++ b/scripts/data_audit.py
@@ -1,0 +1,131 @@
+import argparse
+from collections import Counter
+from pathlib import Path
+from typing import List, Tuple, Dict
+
+import numpy as np
+from src.data_pipeline.fakesv_dataset import FakeSVRawDataset
+
+
+def analyze_class_balance(dataset: FakeSVRawDataset) -> Counter:
+    """Print and return class distribution of the dataset."""
+    counts = Counter(dataset.labels)
+    total = sum(counts.values())
+    print("Class distribution:")
+    for label, count in counts.items():
+        pct = 100.0 * count / total if total else 0.0
+        print(f"  {label}: {count} ({pct:.2f}%)")
+    return counts
+
+
+def analyze_sources(dataset: FakeSVRawDataset) -> Counter:
+    """Analyze distribution of 'source' field if present."""
+    sources = [r.get("source") for r in dataset.records if r.get("source")]
+    if not sources:
+        print("No source information found in records.")
+        return Counter()
+    counts = Counter(sources)
+    print("Top sources:")
+    for src, cnt in counts.most_common(10):
+        print(f"  {src}: {cnt}")
+    return counts
+
+
+def analyze_text_length(dataset: FakeSVRawDataset) -> Dict[str, float]:
+    """Compute average title word count for real vs. fake samples."""
+    lengths = {0: [], 1: []}
+    for rec, label in zip(dataset.records, dataset.labels):
+        wc = len((rec.get("title") or "").split())
+        lengths[int(label)].append(wc)
+    avg_real = float(np.mean(lengths[0])) if lengths[0] else 0.0
+    avg_fake = float(np.mean(lengths[1])) if lengths[1] else 0.0
+    print(f"Average title length (real): {avg_real:.2f} words")
+    print(f"Average title length (fake): {avg_fake:.2f} words")
+    return {"real": avg_real, "fake": avg_fake}
+
+
+def analyze_images(dataset: FakeSVRawDataset, image_root: Path) -> Tuple[List[Tuple[int, int]], Counter]:
+    """Compute average image dimensions and format distribution."""
+    from PIL import Image
+
+    dims: List[Tuple[int, int]] = []
+    formats: Counter = Counter()
+    for rec in dataset.records:
+        img_path = None
+        for key in ("image", "image_path", "img_path", "img"):
+            if key in rec and rec[key]:
+                img_path = rec[key]
+                break
+        if not img_path:
+            continue
+        path = image_root / img_path
+        if not path.exists():
+            continue
+        try:
+            with Image.open(path) as im:
+                dims.append(im.size)  # (width, height)
+                if im.format:
+                    formats[im.format.lower()] += 1
+        except Exception:
+            continue
+    if dims:
+        arr = np.array(dims)
+        avg_w, avg_h = arr.mean(axis=0)
+        print(f"Average image size: {avg_w:.1f}x{avg_h:.1f}")
+    else:
+        print("No images found for analysis.")
+    if formats:
+        print("Image format distribution:")
+        for fmt, cnt in formats.items():
+            print(f"  {fmt}: {cnt}")
+    return dims, formats
+
+
+def embedding_analysis(dataset: FakeSVRawDataset, out_dir: Path) -> None:
+    """Run SBERT + t-SNE embedding visualization if dependencies are available."""
+    try:
+        from sentence_transformers import SentenceTransformer
+        from sklearn.manifold import TSNE
+        import matplotlib.pyplot as plt
+    except Exception as e:  # pragma: no cover
+        print(f"Embedding analysis skipped: {e}")
+        return
+
+    titles = [rec.get("title") or "" for rec in dataset.records]
+    labels = dataset.labels
+
+    model = SentenceTransformer('all-MiniLM-L6-v2')
+    emb = model.encode(titles, show_progress_bar=False)
+
+    tsne = TSNE(n_components=2, init='random', learning_rate='auto')
+    coords = tsne.fit_transform(emb)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    plt.figure(figsize=(6, 6))
+    plt.scatter(coords[:, 0], coords[:, 1], c=labels, cmap='coolwarm', alpha=0.7, s=10)
+    plt.title('t-SNE of SBERT embeddings')
+    plt.savefig(out_dir / 'sbert_tsne.png', dpi=150)
+    plt.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="FakeSV data auditing utilities")
+    parser.add_argument('--data-root', type=str, required=True, help='Path to FakeSV data directory')
+    parser.add_argument('--image-root', type=str, default=None, help='Optional root dir for images referenced in records')
+    parser.add_argument('--output-dir', type=str, default='audit_outputs', help='Directory to save plots or artifacts')
+    parser.add_argument('--embedding-analysis', action='store_true', help='Run SBERT + t-SNE analysis')
+    args = parser.parse_args()
+
+    dataset = FakeSVRawDataset(args.data_root)
+
+    analyze_class_balance(dataset)
+    analyze_sources(dataset)
+    analyze_text_length(dataset)
+    if args.image_root:
+        analyze_images(dataset, Path(args.image_root))
+    if args.embedding_analysis:
+        embedding_analysis(dataset, Path(args.output_dir))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run_ablation.py
+++ b/scripts/run_ablation.py
@@ -1,0 +1,38 @@
+"""Utility to run simple ablation studies on modality usage."""
+
+import dataclasses
+
+from src.train import TrainConfig, main as train_main
+
+
+def run_ablation_studies(base_cfg: TrainConfig):
+    results = {}
+
+    # Text only
+    cfg = dataclasses.replace(base_cfg)
+    cfg.use_visual = False
+    cfg.use_meta = False
+    results["text_only"] = train_main(cfg)
+
+    # Visual only
+    cfg = dataclasses.replace(base_cfg)
+    cfg.use_visual = True
+    cfg.use_text = False
+    cfg.use_meta = False
+    results["visual_only"] = train_main(cfg)
+
+    # Metadata only
+    cfg = dataclasses.replace(base_cfg)
+    cfg.use_visual = False
+    cfg.use_text = False
+    cfg.use_meta = True
+    results["meta_only"] = train_main(cfg)
+
+    # Full model
+    cfg = dataclasses.replace(base_cfg)
+    cfg.use_visual = True
+    cfg.use_text = True
+    cfg.use_meta = True
+    results["full_model"] = train_main(cfg)
+
+    return results

--- a/src/data_pipeline/dataloader.py
+++ b/src/data_pipeline/dataloader.py
@@ -1,0 +1,135 @@
+import os
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+from transformers import AutoTokenizer
+
+import torchvision.transforms as T
+
+
+def get_video_transform():
+    """Default transform for video frames."""
+    return T.Compose([
+        T.Resize((224, 224)),
+        T.ToTensor(),
+        T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+    ])
+
+
+class FakeNewsDataset(Dataset):
+    """Dataset wrapper around the FakeSV metadata layout.
+
+    Each sample returns tokenised text inputs, a stack of video frames, a
+    metadata feature vector and the binary label (0 real, 1 fake).
+    """
+
+    def __init__(self,
+                 root_dir: str,
+                 split: str = "train",
+                 transform: Optional[T.Compose] = None,
+                 text_model_name: str = "bert-base-uncased",
+                 max_length: int = 128,
+                 scaler: Optional[object] = None):
+        self.root_dir = root_dir
+        self.transform = transform or get_video_transform()
+        self.split = split
+        self.scaler = scaler
+
+        # --- Load main metadata
+        meta_path = os.path.join(root_dir, "metadata.csv")
+        if not os.path.exists(meta_path):
+            raise FileNotFoundError(f"metadata.csv not found in {root_dir}")
+        self.meta_df = pd.read_csv(meta_path)
+
+        # --- Apply official split
+        split_file = os.path.join(root_dir, f"{split}.txt")
+        if not os.path.exists(split_file):
+            raise FileNotFoundError(f"Split file {split}.txt missing in {root_dir}")
+        with open(split_file, "r") as f:
+            video_ids_in_split = [line.strip() for line in f.readlines()]
+        self.meta_df = self.meta_df[self.meta_df["video_id"].isin(video_ids_in_split)].reset_index(drop=True)
+
+        # --- Tokeniser
+        self.tokenizer = AutoTokenizer.from_pretrained(text_model_name)
+        self.max_length = max_length
+
+        # --- Preprocess metadata
+        self._preprocess_metadata()
+
+    def _preprocess_metadata(self):
+        """Normalise and scale numerical metadata columns."""
+        from sklearn.preprocessing import StandardScaler
+
+        numerical_features = ["like_count", "share_count", "comment_count"]
+        for feat in numerical_features:
+            self.meta_df[feat] = self.meta_df[feat].fillna(0)
+
+        if self.split == "train":
+            self.scaler = StandardScaler()
+            self.meta_df[numerical_features] = self.scaler.fit_transform(self.meta_df[numerical_features])
+        else:
+            if self.scaler is None:
+                raise RuntimeError("Scaler must be provided for non-training split")
+            self.meta_df[numerical_features] = self.scaler.transform(self.meta_df[numerical_features])
+
+        # Convert verified flag to int
+        self.meta_df["user_verified"] = self.meta_df["user_verified"].astype(int)
+
+    def _sample_video_frames(self, video_path: str, num_frames: int = 16):
+        """Uniformly sample frames from a video file."""
+        import cv2
+
+        cap = cv2.VideoCapture(video_path)
+        total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        frame_indices = np.linspace(0, total_frames - 1, num_frames, dtype=np.int32)
+
+        frames = []
+        for idx in frame_indices:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+            ret, frame = cap.read()
+            if ret:
+                frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                frames.append(Image.fromarray(frame))
+        cap.release()
+        return frames
+
+    def __getitem__(self, idx: int):
+        row = self.meta_df.iloc[idx]
+        video_id = row["video_id"]
+        label = row["label"]
+
+        # Text modality
+        text = f"{row['title']} [SEP] {row['description']}"
+        text_inputs = self.tokenizer(
+            text,
+            padding="max_length",
+            truncation=True,
+            max_length=self.max_length,
+            return_tensors="pt",
+        )
+
+        # Visual modality
+        video_path = os.path.join(self.root_dir, "videos", f"{video_id}.mp4")
+        frames = self._sample_video_frames(video_path, num_frames=16)
+        if self.transform:
+            frames = torch.stack([self.transform(frame) for frame in frames])
+
+        # Metadata modality
+        meta_features = torch.tensor(
+            [
+                row["like_count"],
+                row["share_count"],
+                row["comment_count"],
+                row["user_verified"],
+            ],
+            dtype=torch.float32,
+        )
+
+        return text_inputs, frames, meta_features, int(label)
+
+    def __len__(self) -> int:
+        return len(self.meta_df)

--- a/src/models/advanced_fusion.py
+++ b/src/models/advanced_fusion.py
@@ -1,0 +1,87 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from transformers import AutoModel
+
+
+class HierarchicalFusionModel(nn.Module):
+    """Text, visual and metadata fusion with cross-modal attention."""
+
+    def __init__(self, config):
+        super().__init__()
+
+        # Text encoder
+        self.text_encoder = AutoModel.from_pretrained(config.text_model_name)
+        text_dim = self.text_encoder.config.hidden_size
+
+        # Visual encoder - simple 3D CNN
+        self.visual_encoder = nn.Sequential(
+            nn.Conv3d(3, 64, kernel_size=(3, 3, 3), padding=1),
+            nn.ReLU(),
+            nn.MaxPool3d((1, 2, 2)),
+            nn.Conv3d(64, 128, kernel_size=(3, 3, 3), padding=1),
+            nn.ReLU(),
+            nn.MaxPool3d((2, 2, 2)),
+            nn.AdaptiveAvgPool3d((1, 1, 1)),
+        )
+        visual_dim = 128
+
+        # Metadata encoder
+        self.meta_encoder = nn.Sequential(
+            nn.Linear(4, 32),
+            nn.ReLU(),
+            nn.Dropout(0.3),
+        )
+        meta_dim = 32
+
+        # Cross-modal attention
+        self.cross_attention = nn.MultiheadAttention(
+            embed_dim=text_dim,
+            num_heads=8,
+            batch_first=True,
+        )
+
+        # Classifier
+        self.classifier = nn.Sequential(
+            nn.Linear(text_dim + visual_dim + meta_dim, 512),
+            nn.ReLU(),
+            nn.Dropout(0.5),
+            nn.Linear(512, config.num_labels),
+        )
+
+    def forward(self, text_input, video_frames, meta_features):
+        # Text features
+        text_outputs = self.text_encoder(**text_input)
+        text_features = text_outputs.last_hidden_state  # (B, L, H)
+
+        # Visual features
+        b, f, c, h, w = video_frames.shape
+        video_input = video_frames.permute(0, 2, 1, 3, 4)
+        visual_features = self.visual_encoder(video_input).view(b, -1)
+
+        # Metadata features
+        meta_features = self.meta_encoder(meta_features)
+
+        # Cross-modal attention: attend text tokens to visual global feature
+        cls_token = text_features[:, 0:1, :]
+        visual_expanded = visual_features.unsqueeze(1).repeat(1, text_features.size(1), 1)
+        attended, _ = self.cross_attention(
+            query=text_features,
+            key=visual_expanded,
+            value=visual_expanded,
+        )
+        attended_pooled = attended.mean(dim=1)
+
+        combined = torch.cat([attended_pooled, visual_features, meta_features], dim=1)
+        return self.classifier(combined)
+
+
+class SimpleFusionModel(nn.Module):
+    """Very small baseline using only metadata features."""
+
+    def __init__(self, config):
+        super().__init__()
+        self.classifier = nn.Linear(4, config.num_labels)
+
+    def forward(self, text_input, video_frames, meta_features):
+        return self.classifier(meta_features)

--- a/src/models/model.py
+++ b/src/models/model.py
@@ -1,0 +1,9 @@
+from .advanced_fusion import HierarchicalFusionModel, SimpleFusionModel
+
+
+def get_model(config):
+    """Factory for creating models based on configuration."""
+    if getattr(config, "model_name", "hierarchical_fusion") == "hierarchical_fusion":
+        return HierarchicalFusionModel(config)
+    else:
+        return SimpleFusionModel(config)

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,109 @@
+"""Minimal training script using the new dataset and model.
+
+This is intended as a starting point; real experiments should expand on
+this to include proper logging, checkpointing and hyper-parameter tuning.
+"""
+
+from dataclasses import dataclass
+
+import torch
+from torch.utils.data import DataLoader
+
+from data_pipeline.dataloader import FakeNewsDataset, get_video_transform
+from models.model import get_model
+from utils.metrics import MetricsCalculator
+
+
+@dataclass
+class TrainConfig:
+    data_root: str
+    model_name: str = "hierarchical_fusion"
+    text_model_name: str = "bert-base-uncased"
+    num_labels: int = 2
+    use_text: bool = True
+    use_visual: bool = True
+    use_meta: bool = True
+    batch_size: int = 2
+    epochs: int = 1
+    lr: float = 1e-4
+
+
+def train_one_epoch(model, loader, optim, device, metrics, cfg):
+    model.train()
+    for text_inputs, frames, meta, labels in loader:
+        text_inputs = {k: v.squeeze(1).to(device) for k, v in text_inputs.items()}
+        frames = frames.to(device)
+        meta = meta.to(device)
+        labels = labels.to(device)
+
+        if not cfg.use_text:
+            text_inputs = {k: torch.zeros_like(v) for k, v in text_inputs.items()}
+        if not cfg.use_visual:
+            frames = torch.zeros_like(frames)
+        if not cfg.use_meta:
+            meta = torch.zeros_like(meta)
+
+        optim.zero_grad()
+        outputs = model(text_inputs, frames, meta)
+        loss = torch.nn.functional.cross_entropy(outputs, labels)
+        loss.backward()
+        optim.step()
+
+        metrics.update(outputs.detach(), labels.detach())
+
+
+@torch.no_grad()
+def evaluate(model, loader, device, metrics, cfg):
+    model.eval()
+    for text_inputs, frames, meta, labels in loader:
+        text_inputs = {k: v.squeeze(1).to(device) for k, v in text_inputs.items()}
+        frames = frames.to(device)
+        meta = meta.to(device)
+        labels = labels.to(device)
+
+        if not cfg.use_text:
+            text_inputs = {k: torch.zeros_like(v) for k, v in text_inputs.items()}
+        if not cfg.use_visual:
+            frames = torch.zeros_like(frames)
+        if not cfg.use_meta:
+            meta = torch.zeros_like(meta)
+
+        outputs = model(text_inputs, frames, meta)
+        metrics.update(outputs, labels)
+
+
+def main(cfg: TrainConfig):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    transform = get_video_transform()
+    train_ds = FakeNewsDataset(cfg.data_root, split="train", transform=transform, text_model_name=cfg.text_model_name)
+    val_ds = FakeNewsDataset(cfg.data_root, split="val", transform=transform, text_model_name=cfg.text_model_name, scaler=train_ds.scaler)
+
+    train_loader = DataLoader(train_ds, batch_size=cfg.batch_size, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=cfg.batch_size)
+
+    model = get_model(cfg).to(device)
+    optim = torch.optim.AdamW(model.parameters(), lr=cfg.lr)
+
+    train_metrics = MetricsCalculator()
+    val_metrics = MetricsCalculator()
+
+    for epoch in range(cfg.epochs):
+        train_metrics.reset()
+        train_one_epoch(model, train_loader, optim, device, train_metrics, cfg)
+        train_results = train_metrics.compute()
+
+        val_metrics.reset()
+        evaluate(model, val_loader, device, val_metrics, cfg)
+        val_results = val_metrics.compute()
+
+        print(f"Epoch {epoch}: Train F1={train_results['f1_score']:.4f} | Val F1={val_results['f1_score']:.4f}")
+        last_f1 = val_results["f1_score"]
+
+
+    return last_f1
+
+if __name__ == "__main__":
+    # Example usage; adjust paths and hyper-parameters as needed.
+    cfg = TrainConfig(data_root="./fakesv")
+    main(cfg)

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -1,0 +1,40 @@
+from typing import Dict
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from sklearn.metrics import f1_score, precision_score, recall_score, roc_auc_score
+
+
+class MetricsCalculator:
+    """Accumulates predictions and computes common classification metrics."""
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.all_preds = []
+        self.all_labels = []
+        self.all_probs = []
+
+    def update(self, logits: torch.Tensor, labels: torch.Tensor):
+        probs = F.softmax(logits, dim=1)
+        preds = torch.argmax(probs, dim=1)
+        self.all_preds.extend(preds.detach().cpu().numpy())
+        self.all_labels.extend(labels.detach().cpu().numpy())
+        self.all_probs.extend(probs.detach().cpu().numpy())
+
+    def compute(self) -> Dict[str, float]:
+        labels = np.array(self.all_labels)
+        preds = np.array(self.all_preds)
+        probs = np.array(self.all_probs)
+        metrics = {
+            "accuracy": float(np.mean(labels == preds)),
+            "precision": precision_score(labels, preds, average="macro", zero_division=0),
+            "recall": recall_score(labels, preds, average="macro", zero_division=0),
+            "f1_score": f1_score(labels, preds, average="macro", zero_division=0),
+        }
+        # Binary classification AUC requires probabilities of positive class
+        if probs.ndim == 2 and probs.shape[1] == 2:
+            metrics["auc_roc"] = roc_auc_score(labels, probs[:, 1])
+        return metrics


### PR DESCRIPTION
## Summary
- add FakeSV-aware dataloader using metadata splits and normalized engagement counts
- introduce hierarchical fusion model with cross-modal attention across text, video, and metadata
- provide metrics helper, training loop enhancements, ablation script, and dataset auditing utility with README instructions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ac63b4c2188332931747c2c9755511